### PR TITLE
Dev/multiple evals

### DIFF
--- a/config/base.yaml
+++ b/config/base.yaml
@@ -2,6 +2,7 @@
 MetaArguments:
   global_seed: 1337
   log_file_path: plausibility_vaccine.log
+  num_test_cv: 5
 ModelArguments:
   cache_dir: .cache
   pretrained_model_name: albert-base-v2

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -2,7 +2,6 @@
 MetaArguments:
   global_seed: 1337
   log_file_path: plausibility_vaccine.log
-  num_test_cv: 5
 ModelArguments:
   cache_dir: .cache
   pretrained_model_name: albert-base-v2
@@ -23,6 +22,7 @@ FinetuningArguments:
         is_regression: true
         train_file: data/verb_understanding_data/selectional_association_subject/train.csv
         test_file: data/verb_understanding_data/selectional_association_subject/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     verb_object_score:
@@ -31,6 +31,7 @@ FinetuningArguments:
         is_regression: true
         train_file: data/verb_understanding_data/selectional_association_object/train.csv
         test_file: data/verb_understanding_data/selectional_association_object/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     mobility_pred:
@@ -39,6 +40,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Mobility/train.csv
         test_file: data/property_data/Mobility/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     opacity_pred:
@@ -47,6 +49,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Opacity/train.csv
         test_file: data/property_data/Opacity/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     phase_pred:
@@ -55,6 +58,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Phase/train.csv
         test_file: data/property_data/Phase/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     rigidity_pred:
@@ -63,6 +67,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Rigidity/train.csv
         test_file: data/property_data/Rigidity/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     sentience_pred:
@@ -71,6 +76,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Sentience/train.csv
         test_file: data/property_data/Sentience/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     shape_pred:
@@ -79,6 +85,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Shape/train.csv
         test_file: data/property_data/Shape/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     size_pred:
@@ -87,6 +94,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Size/train.csv
         test_file: data/property_data/Size/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     temperature_pred:
@@ -95,6 +103,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Temperature/train.csv
         test_file: data/property_data/Temperature/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     texture_pred:
@@ -103,6 +112,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Texture/train.csv
         test_file: data/property_data/Texture/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     weight_pred:
@@ -111,6 +121,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Weight/train.csv
         test_file: data/property_data/Weight/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
   downstream_tasks:
@@ -120,6 +131,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/plausibility_data/pep_3k/valid.csv
         test_file: data/plausibility_data/pep_3k/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config:
       use_adapter_for_task: false
@@ -129,6 +141,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/plausibility_data/pep_3k/valid.csv
         test_file: data/plausibility_data/pep_3k/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
       use_adapter_for_task: true
@@ -138,6 +151,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/plausibility_data/pep_3k/valid.csv
         test_file: data/plausibility_data/pep_3k/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config:
       fusion:
@@ -160,6 +174,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/plausibility_data/pep_3k/valid.csv
         test_file: data/plausibility_data/pep_3k/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
       fusion:
@@ -182,6 +197,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/plausibility_data/twentyquestions/valid.csv
         test_file: data/plausibility_data/twentyquestions/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config:
       use_adapter_for_task: false
@@ -191,6 +207,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/plausibility_data/twentyquestions/valid.csv
         test_file: data/plausibility_data/twentyquestions/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
       use_adapter_for_task: true
@@ -200,6 +217,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/plausibility_data/twentyquestions/valid.csv
         test_file: data/plausibility_data/twentyquestions/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config:
       fusion:
@@ -222,6 +240,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/plausibility_data/twentyquestions/valid.csv
         test_file: data/plausibility_data/twentyquestions/test.csv
+        num_test_shards: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
       fusion:

--- a/config/baselines.yaml
+++ b/config/baselines.yaml
@@ -2,7 +2,6 @@
 MetaArguments:
   global_seed: 1337
   log_file_path: plausibility_vaccine.log
-  num_test_cv: 5
 ModelArguments:
   cache_dir: .cache
   pretrained_model_name: albert-base-v2
@@ -24,6 +23,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/plausibility_data/pep_3k/valid.csv
         test_file: data/plausibility_data/pep_3k/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config:
       use_adapter_for_task: false
@@ -33,6 +33,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/plausibility_data/pep_3k/valid.csv
         test_file: data/plausibility_data/pep_3k/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
       use_adapter_for_task: true
@@ -42,6 +43,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/plausibility_data/twentyquestions/valid.csv
         test_file: data/plausibility_data/twentyquestions/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config:
       use_adapter_for_task: false
@@ -51,6 +53,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/plausibility_data/twentyquestions/valid.csv
         test_file: data/plausibility_data/twentyquestions/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
       use_adapter_for_task: true

--- a/config/baselines.yaml
+++ b/config/baselines.yaml
@@ -2,6 +2,7 @@
 MetaArguments:
   global_seed: 1337
   log_file_path: plausibility_vaccine.log
+  num_test_cv: 5
 ModelArguments:
   cache_dir: .cache
   pretrained_model_name: albert-base-v2

--- a/config/combined.yaml
+++ b/config/combined.yaml
@@ -2,7 +2,6 @@
 MetaArguments:
   global_seed: 1337
   log_file_path: plausibility_vaccine.log
-  num_test_cv: 5
 ModelArguments:
   cache_dir: .cache
   pretrained_model_name: albert-base-v2
@@ -23,6 +22,7 @@ FinetuningArguments:
         is_regression: true
         train_file: data/verb_understanding_data/selectional_association_subject/train.csv
         test_file: data/verb_understanding_data/selectional_association_subject/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     verb_object_score:
@@ -31,6 +31,7 @@ FinetuningArguments:
         is_regression: true
         train_file: data/verb_understanding_data/selectional_association_object/train.csv
         test_file: data/verb_understanding_data/selectional_association_object/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     mobility_pred:
@@ -39,6 +40,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Mobility/train.csv
         test_file: data/property_data/Mobility/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     opacity_pred:
@@ -47,6 +49,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Opacity/train.csv
         test_file: data/property_data/Opacity/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     phase_pred:
@@ -55,6 +58,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Phase/train.csv
         test_file: data/property_data/Phase/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     rigidity_pred:
@@ -63,6 +67,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Rigidity/train.csv
         test_file: data/property_data/Rigidity/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     sentience_pred:
@@ -71,6 +76,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Sentience/train.csv
         test_file: data/property_data/Sentience/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     shape_pred:
@@ -79,6 +85,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Shape/train.csv
         test_file: data/property_data/Shape/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     size_pred:
@@ -87,6 +94,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Size/train.csv
         test_file: data/property_data/Size/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     temperature_pred:
@@ -95,6 +103,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Temperature/train.csv
         test_file: data/property_data/Temperature/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     texture_pred:
@@ -103,6 +112,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Texture/train.csv
         test_file: data/property_data/Texture/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     weight_pred:
@@ -111,6 +121,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Weight/train.csv
         test_file: data/property_data/Weight/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
   downstream_tasks:
@@ -122,6 +133,7 @@ FinetuningArguments:
           - data/plausibility_data/pep_3k/valid.csv
           - data/plausibility_data/twentyquestions/valid.csv
         test_file: data/plausibility_data/pep_3k/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config:
       use_adapter_for_task: false
@@ -133,6 +145,7 @@ FinetuningArguments:
           - data/plausibility_data/pep_3k/valid.csv
           - data/plausibility_data/twentyquestions/valid.csv
         test_file: data/plausibility_data/pep_3k/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
       use_adapter_for_task: true
@@ -144,6 +157,7 @@ FinetuningArguments:
           - data/plausibility_data/pep_3k/valid.csv
           - data/plausibility_data/twentyquestions/valid.csv
         test_file: data/plausibility_data/pep_3k/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config:
       fusion:
@@ -168,6 +182,7 @@ FinetuningArguments:
           - data/plausibility_data/pep_3k/valid.csv
           - data/plausibility_data/twentyquestions/valid.csv
         test_file: data/plausibility_data/pep_3k/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
       fusion:
@@ -190,6 +205,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/plausibility_data/twentyquestions/valid.csv
         test_file: data/plausibility_data/twentyquestions/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config:
       use_adapter_for_task: false
@@ -201,6 +217,7 @@ FinetuningArguments:
           - data/plausibility_data/pep_3k/valid.csv
           - data/plausibility_data/twentyquestions/valid.csv
         test_file: data/plausibility_data/twentyquestions/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
       use_adapter_for_task: true
@@ -212,6 +229,7 @@ FinetuningArguments:
           - data/plausibility_data/pep_3k/valid.csv
           - data/plausibility_data/twentyquestions/valid.csv
         test_file: data/plausibility_data/twentyquestions/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config:
       fusion:
@@ -236,6 +254,7 @@ FinetuningArguments:
           - data/plausibility_data/pep_3k/valid.csv
           - data/plausibility_data/twentyquestions/valid.csv
         test_file: data/plausibility_data/twentyquestions/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
       fusion:

--- a/config/combined.yaml
+++ b/config/combined.yaml
@@ -2,6 +2,7 @@
 MetaArguments:
   global_seed: 1337
   log_file_path: plausibility_vaccine.log
+  num_test_cv: 5
 ModelArguments:
   cache_dir: .cache
   pretrained_model_name: albert-base-v2

--- a/config/endlines.yaml
+++ b/config/endlines.yaml
@@ -2,7 +2,6 @@
 MetaArguments:
   global_seed: 1337
   log_file_path: plausibility_vaccine.log
-  num_test_cv: 5
 ModelArguments:
   cache_dir: .cache
   pretrained_model_name: albert-base-v2
@@ -24,6 +23,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/plausibility_data/pep_3k/valid.csv
         test_file: data/plausibility_data/pep_3k/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config:
       fusion:
@@ -46,6 +46,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/plausibility_data/pep_3k/valid.csv
         test_file: data/plausibility_data/pep_3k/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
       fusion:
@@ -68,6 +69,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/plausibility_data/twentyquestions/valid.csv
         test_file: data/plausibility_data/twentyquestions/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config:
       fusion:
@@ -90,6 +92,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/plausibility_data/twentyquestions/valid.csv
         test_file: data/plausibility_data/twentyquestions/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
       fusion:

--- a/config/endlines.yaml
+++ b/config/endlines.yaml
@@ -2,6 +2,7 @@
 MetaArguments:
   global_seed: 1337
   log_file_path: plausibility_vaccine.log
+  num_test_cv: 5
 ModelArguments:
   cache_dir: .cache
   pretrained_model_name: albert-base-v2

--- a/config/pretraining.yaml
+++ b/config/pretraining.yaml
@@ -2,7 +2,6 @@
 MetaArguments:
   global_seed: 1337
   log_file_path: plausibility_vaccine.log
-  num_test_cv: 5
 ModelArguments:
   cache_dir: .cache
   pretrained_model_name: albert-base-v2
@@ -23,6 +22,7 @@ FinetuningArguments:
         is_regression: true
         train_file: data/verb_understanding_data/selectional_association_subject/train.csv
         test_file: data/verb_understanding_data/selectional_association_subject/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     verb_object_score:
@@ -31,6 +31,7 @@ FinetuningArguments:
         is_regression: true
         train_file: data/verb_understanding_data/selectional_association_object/train.csv
         test_file: data/verb_understanding_data/selectional_association_object/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     mobility_pred:
@@ -39,6 +40,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Mobility/train.csv
         test_file: data/property_data/Mobility/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     opacity_pred:
@@ -47,6 +49,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Opacity/train.csv
         test_file: data/property_data/Opacity/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     phase_pred:
@@ -55,6 +58,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Phase/train.csv
         test_file: data/property_data/Phase/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     rigidity_pred:
@@ -63,6 +67,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Rigidity/train.csv
         test_file: data/property_data/Rigidity/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     sentience_pred:
@@ -71,6 +76,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Sentience/train.csv
         test_file: data/property_data/Sentience/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     shape_pred:
@@ -79,6 +85,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Shape/train.csv
         test_file: data/property_data/Shape/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     size_pred:
@@ -87,6 +94,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Size/train.csv
         test_file: data/property_data/Size/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     temperature_pred:
@@ -95,6 +103,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Temperature/train.csv
         test_file: data/property_data/Temperature/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     texture_pred:
@@ -103,6 +112,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Texture/train.csv
         test_file: data/property_data/Texture/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
     weight_pred:
@@ -111,6 +121,7 @@ FinetuningArguments:
         is_regression: false
         train_file: data/property_data/Weight/train.csv
         test_file: data/property_data/Weight/test.csv
+        num_test_cv: 5
       adapter_args:
         adapter_config: seq_bn[reduction_factor=64]
   downstream_tasks: {}

--- a/config/pretraining.yaml
+++ b/config/pretraining.yaml
@@ -2,6 +2,7 @@
 MetaArguments:
   global_seed: 1337
   log_file_path: plausibility_vaccine.log
+  num_test_cv: 5
 ModelArguments:
   cache_dir: .cache
   pretrained_model_name: albert-base-v2

--- a/plausibility_vaccine/data.py
+++ b/plausibility_vaccine/data.py
@@ -30,9 +30,7 @@ def preprocess_function(
     return result
 
 
-def get_data(
-    data_args: DataArguments, num_test_cv: int
-) -> Tuple[DatasetDict, Optional[List[str]]]:
+def get_data(data_args: DataArguments) -> Tuple[DatasetDict, Optional[List[str]]]:
     logging.info(f'Loading training dataset with files: {data_args.train_file}')
     train_dataset = load_dataset('csv', data_files=data_args.train_file)
     train_dataset = concatenate_datasets(train_dataset.values())
@@ -41,10 +39,12 @@ def get_data(
     test_dataset = load_dataset('csv', data_files=data_args.test_file)
     test_dataset = concatenate_datasets(test_dataset.values())
 
-    logging.info(f'Breaking test dataset into {num_test_cv} shards')
+    logging.info(f'Breaking test dataset into {data_args.num_test_cv} shards')
     test_shards = {}
-    for i in range(num_test_cv):
-        test_shards[f'shard-{i}'] = test_dataset.shard(num_shards=num_test_cv, index=i)
+    for i in range(data_args.num_test_cv):
+        test_shards[f'shard-{i}'] = test_dataset.shard(
+            num_shards=data_args.num_test_cv, index=i
+        )
 
     raw_datasets = DatasetDict(
         {'train': train_dataset, 'test': DatasetDict(test_shards)}

--- a/plausibility_vaccine/main.py
+++ b/plausibility_vaccine/main.py
@@ -24,7 +24,7 @@ def main() -> None:
     meta_args, model_args, training_args, finetuning_args = parse_args(config_file_path)
     setup_basic_logging(meta_args.log_file_path)
     seed_everything(meta_args.global_seed)
-    run(model_args, training_args, finetuning_args)
+    run(meta_args, model_args, training_args, finetuning_args)
 
 
 if __name__ == '__main__':

--- a/plausibility_vaccine/main.py
+++ b/plausibility_vaccine/main.py
@@ -24,7 +24,7 @@ def main() -> None:
     meta_args, model_args, training_args, finetuning_args = parse_args(config_file_path)
     setup_basic_logging(meta_args.log_file_path)
     seed_everything(meta_args.global_seed)
-    run(meta_args, model_args, training_args, finetuning_args)
+    run(model_args, training_args, finetuning_args)
 
 
 if __name__ == '__main__':

--- a/plausibility_vaccine/run.py
+++ b/plausibility_vaccine/run.py
@@ -18,13 +18,11 @@ from plausibility_vaccine.fine_tune import load_pretrained_model
 from plausibility_vaccine.util.args import (
     FinetuningArgument,
     FinetuningArguments,
-    MetaArguments,
     ModelArguments,
 )
 
 
 def run(
-    meta_args: MetaArguments,
     model_args: ModelArguments,
     training_args: TrainingArguments,
     finetuning_args: FinetuningArguments,
@@ -37,22 +35,21 @@ def run(
 
     for task_name, task_args in finetuning_args.pretraining_tasks.items():
         logging.info('Running %s', task_name)
-        _run_task(meta_args, model_args, training_args, task_args)
+        _run_task(model_args, training_args, task_args)
 
     for task_name, task_args in finetuning_args.downstream_tasks.items():
         logging.info('Running %s', task_name)
-        _run_task(meta_args, model_args, training_args, task_args)
+        _run_task(model_args, training_args, task_args)
 
 
 def _run_task(
-    meta_args: MetaArguments,
     model_args: ModelArguments,
     training_args: TrainingArguments,
     task_args: FinetuningArgument,
 ) -> None:
     logging.info('Setting up pre-training for task: %s', task_args.data_args.task_name)
     data_args, adapter_args = task_args.data_args, task_args.adapter_args
-    raw_datasets, label_list = get_data(data_args, meta_args.num_test_cv)
+    raw_datasets, label_list = get_data(data_args)
 
     model, tokenizer = load_pretrained_model(
         model_args,

--- a/plausibility_vaccine/run.py
+++ b/plausibility_vaccine/run.py
@@ -18,11 +18,13 @@ from plausibility_vaccine.fine_tune import load_pretrained_model
 from plausibility_vaccine.util.args import (
     FinetuningArgument,
     FinetuningArguments,
+    MetaArguments,
     ModelArguments,
 )
 
 
 def run(
+    meta_args: MetaArguments,
     model_args: ModelArguments,
     training_args: TrainingArguments,
     finetuning_args: FinetuningArguments,
@@ -35,21 +37,22 @@ def run(
 
     for task_name, task_args in finetuning_args.pretraining_tasks.items():
         logging.info('Running %s', task_name)
-        _run_task(model_args, training_args, task_args)
+        _run_task(meta_args, model_args, training_args, task_args)
 
     for task_name, task_args in finetuning_args.downstream_tasks.items():
         logging.info('Running %s', task_name)
-        _run_task(model_args, training_args, task_args)
+        _run_task(meta_args, model_args, training_args, task_args)
 
 
 def _run_task(
+    meta_args: MetaArguments,
     model_args: ModelArguments,
     training_args: TrainingArguments,
     task_args: FinetuningArgument,
 ) -> None:
     logging.info('Setting up pre-training for task: %s', task_args.data_args.task_name)
     data_args, adapter_args = task_args.data_args, task_args.adapter_args
-    raw_datasets, label_list = get_data(data_args)
+    raw_datasets, label_list = get_data(data_args, meta_args.num_test_cv)
 
     model, tokenizer = load_pretrained_model(
         model_args,
@@ -58,11 +61,12 @@ def _run_task(
     )
 
     with training_args.main_process_first(desc='dataset map pre-processing'):
-        raw_datasets = raw_datasets.map(
-            lambda batch: preprocess_function(batch, tokenizer, label_list),
-            batched=True,
-            desc='Running tokenizer on dataset',
-        )
+        for split in ['train', 'test']:
+            raw_datasets[split] = raw_datasets[split].map(
+                lambda batch: preprocess_function(batch, tokenizer, label_list),
+                batched=True,
+                desc=f'Running tokenizer on {split} dataset',
+            )
 
     # Evaluation Metrics
     if data_args.is_regression:

--- a/plausibility_vaccine/util/args.py
+++ b/plausibility_vaccine/util/args.py
@@ -18,6 +18,10 @@ class MetaArguments:
         default=1337,
         metadata={'help': 'Random seed to use for reproducibiility.'},
     )
+    num_test_cv: int = field(
+        metadata={'help': 'Number of test splits to do for uncertainty estimates.'},
+        default=1,
+    )
 
     def __post_init__(self) -> None:
         if self.log_file_path is not None:

--- a/plausibility_vaccine/util/args.py
+++ b/plausibility_vaccine/util/args.py
@@ -18,10 +18,6 @@ class MetaArguments:
         default=1337,
         metadata={'help': 'Random seed to use for reproducibiility.'},
     )
-    num_test_cv: int = field(
-        metadata={'help': 'Number of test splits to do for uncertainty estimates.'},
-        default=1,
-    )
 
     def __post_init__(self) -> None:
         if self.log_file_path is not None:
@@ -41,6 +37,10 @@ class DataArguments:
     )
     test_file: Union[str, List[str]] = field(
         metadata={'help': 'A csv or list of csv files containing the test data.'},
+    )
+    num_test_cv: int = field(
+        metadata={'help': 'Number of test splits to do for uncertainty estimates.'},
+        default=1,
     )
 
     def __post_init__(self) -> None:


### PR DESCRIPTION
Evaluation metrics on the test set will be automatically prefixed with the appropriate shard, e.g.

```
shard-1-accuracy, shard-2-accuracy, ....
shard-1-precision, shard-2-precision, ...
...
```